### PR TITLE
Debug ansible_service_mgr before acting on it

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,9 @@
     src: /etc/openresty
     path: /etc/nginx
 
-- name: link openresty init script as nginx
+- debug: var=ansible_service_mgr
+
+- name: link openresty init script as nginx for service
   file:
     state: link
     src: /etc/init.d/openresty


### PR DESCRIPTION
```
20:52:49 TASK [refinery29.openresty : link openresty init script as nginx] **************
20:52:49 Saturday 21 October 2017  00:52:49 +0000 (0:00:00.498)       1:22:13.166 ****** 
20:52:49 skipping: [jump01.stage.rf29.net]
20:52:49 
20:52:49 TASK [refinery29.openresty : create nginx service for systemd] *****************
20:52:49 Saturday 21 October 2017  00:52:49 +0000 (0:00:00.082)       1:22:13.248 ****** 
20:52:49 skipping: [jump01.stage.rf29.net]
```
shouldn't be happening, this will expose the fact that is being tested for each of those tasks.