### PR TITLE
Always link nginx service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,6 @@
     state: link
     src: /etc/init.d/openresty
     path: /etc/init.d/nginx
-  when: ansible_service_mgr == 'service'
 
 - name: create nginx service for systemd
   copy:


### PR DESCRIPTION
This fixes the issue with Ansible<2.4 against Ubuntu trusty where ansible_service_mgr is reported as 'upstart', thus not linking the init file.

The shippable failure is due to unconfigured shippable and can be ignored. 