### PR TITLE
Create /var/log/nginx

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,11 +31,12 @@
 - name: create standard nginx directories
   file:
     state: directory
-    path: /etc/nginx/{{ item }}
+    path: "{{ item }}"
   with_items:
-    - conf.d
-    - sites-enabled
-    - sites-available
+    - /etc/nginx/conf.d
+    - /etc/nginx/sites-enabled
+    - /etc/nginx/sites-available
+    - /var/log/nginx
 
 - name: install default nginx configuration
   template:


### PR DESCRIPTION
This is a logical directory to create if we are creating
/etc/nginx/sites-*. Currently there is a bug in a downstream consumer
role, authproxy, which needs this, and it makes more sense here than
repeatedly in all roles which use this.