### PR TITLE
Stop nginx before removing default server config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,14 @@
 
 - name: install OpenResty package
   apt: name=openresty
+  register: install
+
+# This is required so that when the following task replaces the defaulct nginx.conf
+# with a default server listening on 80, those agents aren't orphaned as they will
+# cause subsequent attempts to start nginx to fail with a conflict on 80
+- name: stop process started by install
+  when: install | changed
+  service: name=openresty state=stopped
 
 - name: link /etc/openresty to /etc/nginx
   file:


### PR DESCRIPTION
This is required so that when the following task replaces the defaulct nginx.conf
with a default server listening on 80, those agents aren't orphaned as they will
cause subsequent attempts to start nginx to fail with a conflict on 80