### PR TITLE
Allows configuration of the PID file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 openresty_keepalive_timeout: 65
 openresty_worker_connections: 1024
+openresty_pidfile: /usr/local/openresty/nginx/logs/nginx.pid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,9 +23,12 @@
     path: /etc/init.d/nginx
 
 - name: create nginx service for systemd
-  copy:
-    src: etc/systemd/system/nginx.service
+  template:
+    src: etc/systemd/system/nginx.service.j2
     dest: /etc/systemd/system/nginx.service
+    owner: root
+    group: root
+    mode: 0644
   when: ansible_service_mgr == 'systemd'
 
 - name: create standard nginx directories

--- a/templates/etc/systemd/system/nginx.service.j2
+++ b/templates/etc/systemd/system/nginx.service.j2
@@ -4,7 +4,7 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
-PIDFile=/usr/local/openresty/nginx/logs/nginx.pid
+PIDFile={{ openresty_pidfile }}
 ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t
 ExecStart=/usr/local/openresty/nginx/sbin/nginx
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
Allows configuration of the systemd service PID file location via a new `openresty_pidfile` variable