### PR TITLE
Add Vagrant tests for rhel distros

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-    machines = %w(bento/ubuntu-16.04 bento/ubuntu-14.04)
+    machines = %w(bento/ubuntu-16.04 bento/ubuntu-14.04 bento/centos-6.9 bento/centos-7.3 bento/fedora-26)
     machine_names = machines.map do |box|
         box.gsub(/(\/|\.)/, '-')
     end
@@ -12,6 +12,7 @@ Vagrant.configure(2) do |config|
                     raw_arguments: %w(-vv --diff),
                     playbook: 'playbook.yml',
                     groups: { role_name => machine_names },
+                    host_vars: { "bento-fedora-26" => {"ansible_python_interpreter" => "/usr/bin/python3"}},
                     limit: :all
             end
         end

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,22 @@
 ---
 - hosts: "{{ playbook_dir | basename }}"
   become: yes
+  pre_tasks:
+    - block:
+      - yum: name=libselinux-python
+      - yum: name=epel-release
+      - yum: name={{ item }}
+        with_items:
+          - python-urllib3
+          - python2-ndg_httpsclient
+      when:
+        - ansible_distribution_file_variety == "RedHat"
+        - ansible_distribution_major_version == "6"
+    - block:
+      - apt: name=python-pip
+      - pip: name=ndg-httpsclient state=present
+      when:
+        - ansible_distribution == "Ubuntu"
+        - ansible_distribution_major_version == "14"
   roles:
     - ../{{ playbook_dir | basename }}


### PR DESCRIPTION
This adds the centos-6.9, centos-7.3, and fedora-26 bento boxes to the
Vagrant config along with prerequisites for python sni usage for
systems distributed with old versions of python.