### PR TITLE
Remove nginx init script before creating link for openresty

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 Vagrant.configure(2) do |config|
     machines = %w(
+                    bento/ubuntu-18.04
                     bento/ubuntu-16.04
                     bento/ubuntu-14.04
                     bento/centos-6.9

--- a/playbook.yml
+++ b/playbook.yml
@@ -13,7 +13,7 @@
         - ansible_distribution_file_variety == "RedHat"
         - ansible_distribution_major_version == "6"
     - block:
-      - apt: name=python-pip
+      - apt: name=python-pip update_cache=yes
       - pip: name=ndg-httpsclient state=present
       when:
         - ansible_distribution == "Ubuntu"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
 
 - debug: var=ansible_service_mgr
 
+- name: remove any existing nginx init script
+  file:
+    state: absent
+    path: /etc/init.d/nginx
+
 - name: link openresty init script as nginx for service
   file:
     state: link


### PR DESCRIPTION
I believe this only does anything if nginx has been installed previously.